### PR TITLE
Removing global/static data (for multi-user web context)

### DIFF
--- a/src/dataStore/DataInOut.java
+++ b/src/dataStore/DataInOut.java
@@ -44,16 +44,16 @@ import solver.GreedyHeuristic;
  */
 public class DataInOut {
 
-    private static String basePath;
-    private static String dataset;
-    private static String scenario;
-    private static DataStorer data;
+    private String basePath;
+    private String dataset;
+    private String scenario;
+    private DataStorer data;
 
-    public static void loadData(String basePath, String dataset, String scenario, DataStorer data) {
-        DataInOut.basePath = basePath;
-        DataInOut.dataset = dataset;
-        DataInOut.scenario = scenario;
-        DataInOut.data = data;
+    public void loadData(String basePath, String dataset, String scenario, DataStorer data) {
+        this.basePath = basePath;
+        this.dataset = dataset;
+        this.scenario = scenario;
+        this.data = data;
 
         System.out.println("Loading Geography...");
         loadGeography();
@@ -70,7 +70,7 @@ public class DataInOut {
         System.out.println("Data Loaded.");
     }
 
-    private static void loadGeography() {
+    private void loadGeography() {
         String path = basePath + "/" + dataset + "/BaseData/CostNetwork/Construction Costs.txt";
         try (BufferedReader br = new BufferedReader(new FileReader(path))) {
             br.readLine();
@@ -130,7 +130,7 @@ public class DataInOut {
         }
     }
 
-    public static void loadCosts() {
+    public void loadCosts() {
         double[][] rightOfWayCosts = new double[0][0];
         double[][] constructionCosts = new double[0][0];
         double[][] routingCosts = new double[0][0];
@@ -288,7 +288,7 @@ public class DataInOut {
         data.setRoutingCosts(routingCosts);
     }
 
-    private static void loadSources() {
+    private void loadSources() {
         String sourcePath = basePath + "/" + dataset + "/Scenarios/" + scenario + "/Sources/Sources.txt";
         try (BufferedReader br = new BufferedReader(new FileReader(sourcePath))) {
             br.readLine();
@@ -312,7 +312,7 @@ public class DataInOut {
         }
     }
 
-    private static void loadSinks() {
+    private void loadSinks() {
         String sinkPath = basePath + "/" + dataset + "/Scenarios/" + scenario + "/Sinks/Sinks.txt";
         try (BufferedReader br = new BufferedReader(new FileReader(sinkPath))) {
             br.readLine();
@@ -339,7 +339,7 @@ public class DataInOut {
         }
     }
 
-    private static void loadTransport() {
+    private void loadTransport() {
         String transportPath = basePath + "/" + dataset + "/Scenarios/" + scenario + "/Transport/Linear.txt";
         try (BufferedReader br = new BufferedReader(new FileReader(transportPath))) {
             br.readLine();
@@ -377,7 +377,7 @@ public class DataInOut {
         }
     }
 
-    private static void loadCandidateGraph() {
+    private void loadCandidateGraph() {
         // Check if file exists
         String candidateGraphPath = basePath + "/" + dataset + "/Scenarios/" + scenario + "/Network/CandidateNetwork/CandidateNetwork.txt";
         if (new File(candidateGraphPath).exists()) {
@@ -461,7 +461,7 @@ public class DataInOut {
         }
     }
 
-    private static void loadDelaunayPairs() {
+    private void loadDelaunayPairs() {
         // Check if file exists
         String delaunayPairsPath = basePath + "/" + dataset + "/Scenarios/" + scenario + "/Network/DelaunayNetwork/DelaunayPaths.txt";
         if (new File(delaunayPairsPath).exists()) {
@@ -492,7 +492,7 @@ public class DataInOut {
         }
     }
 
-    public static void loadPriceConfiguration() {
+    public void loadPriceConfiguration() {
         // Check if file exists
         String pricesPath = basePath + "/" + dataset + "/Scenarios/" + scenario + "/Configurations/priceInput.csv";
         if (new File(pricesPath).exists()) {
@@ -521,7 +521,7 @@ public class DataInOut {
         }
     }
 
-    public static void loadTimeConfiguration() {
+    public void loadTimeConfiguration() {
         // Check if file exists
         String timeConfigurationPath = basePath + "/" + dataset + "/Scenarios/" + scenario + "/Configurations/timeInput.csv";
         if (new File(timeConfigurationPath).exists()) {
@@ -554,7 +554,7 @@ public class DataInOut {
         }
     }
 
-    public static void saveDelaunayPairs() {
+    public void saveDelaunayPairs() {
         HashSet<Edge> delaunayPairs = data.getDelaunayPairs();
 
         String delaunayPairsPath = basePath + "/" + dataset + "/Scenarios/" + scenario + "/Network/DelaunayNetwork/DelaunayPaths.txt";
@@ -582,7 +582,7 @@ public class DataInOut {
         }
     }
 
-    public static void saveCandidateGraph() {
+    public void saveCandidateGraph() {
         HashMap<Edge, Double> graphEdgeCosts = data.getGraphEdgeCosts();
         HashMap<Edge, int[]> graphEdgeRoutes = data.getGraphEdgeRoutes();
         HashMap<Edge, Double> graphEdgeConstructionCosts = data.getGraphEdgeConstructionCosts();
@@ -607,7 +607,7 @@ public class DataInOut {
     }
 
     // Heuristic
-    public static void saveHeuristicSolution(File solutionDirectory, GreedyHeuristic heuristic) {
+    public void saveHeuristicSolution(File solutionDirectory, GreedyHeuristic heuristic) {
         // Collect data.
         Source[] sources = heuristic.getSources();
         Sink[] sinks = heuristic.getSinks();
@@ -656,7 +656,7 @@ public class DataInOut {
     }
 
     // Heuristic
-    public static Solution loadGreedyHeuristicSolution(String solutionPath) {
+    public Solution loadGreedyHeuristicSolution(String solutionPath) {
         Solution soln = new Solution();
         Source[] sources = data.getSources();
         Sink[] sinks = data.getSinks();
@@ -710,7 +710,7 @@ public class DataInOut {
         return soln;
     }
 
-    public static Solution loadSolution(String solutionPath, int timeslot) {
+    public Solution loadSolution(String solutionPath, int timeslot) {
         double threshold = .000001;
         Solution soln = new Solution();
 
@@ -928,7 +928,7 @@ public class DataInOut {
         return soln;
     }
 
-    public static int determineNumTimeslots(String mpsFilePath) {
+    public int determineNumTimeslots(String mpsFilePath) {
         File mpsFile = new File(mpsFilePath);
         HashSet<Integer> timeslots = new HashSet<>();
 
@@ -955,7 +955,7 @@ public class DataInOut {
         return timeslots.size();
     }
 
-    public static void makeShapeFiles(String path, Solution soln) {
+    public void makeShapeFiles(String path, Solution soln) {
         // Make shapefiles if they do not already exist.
         File newDir = new File(path + "/shapeFiles/");
         if (!newDir.exists()) {
@@ -1128,7 +1128,7 @@ public class DataInOut {
         }
     }
 
-    public static void makeCandidateShapeFiles(String path) {
+    public void makeCandidateShapeFiles(String path) {
         // Make shapefiles if they do not already exist.
         File newDir = new File(path + "/shapeFiles/");
         if (!newDir.exists()) {
@@ -1269,7 +1269,7 @@ public class DataInOut {
         }
     }
 
-    public static void makeProjectionFile(String name, String path) {
+    public void makeProjectionFile(String name, String path) {
         try (BufferedWriter bw = new BufferedWriter(new FileWriter(new File(path, name + ".prj")))) {
             bw.write("GEOGCS[\"GCS_North_American_1983\",DATUM[\"D_North_American_1983\",SPHEROID[\"GRS_1980\",6378137.0,298.257222101]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]]");
         } catch (IOException e) {
@@ -1278,7 +1278,7 @@ public class DataInOut {
 
     }
 
-    public static void makeSolutionFile(String path, Solution soln) {
+    public void makeSolutionFile(String path, Solution soln) {
         try (BufferedWriter bw = new BufferedWriter(new FileWriter(new File(path, "solution.csv")))) {
             bw.write("Project Length," + soln.getProjectLength() + "\n");
             bw.write("CRF," + soln.getCRF() + "\n");
@@ -1321,7 +1321,7 @@ public class DataInOut {
         }
     }
 
-    public static void makePriceAggregationFile(String path, String content) {
+    public void makePriceAggregationFile(String path, String content) {
         try (BufferedWriter bw = new BufferedWriter(new FileWriter(path))) {
             bw.write(content);
         } catch (IOException e) {
@@ -1329,7 +1329,7 @@ public class DataInOut {
         }
     }
 
-    public static void makeGenerateFile(String path, Solution soln) {
+    public void makeGenerateFile(String path, Solution soln) {
         File newDir = new File(path + "/genFiles");
         if (true) {
             newDir.mkdir();
@@ -1392,7 +1392,7 @@ public class DataInOut {
     }
 
     // Download file from url
-    public static void downloadFile(String urlPath) {
+    public void downloadFile(String urlPath) {
         HttpURLConnection connection;
 
         try {

--- a/src/dataStore/DataStorer.java
+++ b/src/dataStore/DataStorer.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
+import solver.GreedyHeuristic;
 import solver.Solver;
 
 /**
@@ -18,6 +19,8 @@ public class DataStorer {
     public String scenario;
 
     private Solver solver;
+
+    private DataInOut dataInOut = new DataInOut();
 
     // Geospatial data.
     private int width;  // Number of columns
@@ -83,7 +86,7 @@ public class DataStorer {
 
     public void generateDelaunayPairs() {
         delaunayPairs = solver.generateDelaunayPairs();
-        DataInOut.saveDelaunayPairs();
+        dataInOut.saveDelaunayPairs();
     }
 
     public void generateCandidateGraph() {
@@ -103,7 +106,7 @@ public class DataStorer {
                 graphEdgeRightOfWayCosts = (HashMap<Edge, Double>) costComponents[0];
                 graphEdgeConstructionCosts = (HashMap<Edge, Double>) costComponents[1];
 
-                DataInOut.saveCandidateGraph();
+                dataInOut.saveCandidateGraph();
             }
         } else {
             String text = "";
@@ -153,7 +156,7 @@ public class DataStorer {
 
     public void loadNetworkCosts() {
         if (constructionCosts == null) {
-            DataInOut.loadCosts();
+            dataInOut.loadCosts();
 
             // Make right of way and construction costs
             if (graphEdgeRoutes != null) {
@@ -590,7 +593,7 @@ public class DataStorer {
         solver = s;
 
         // Load data from files.
-        DataInOut.loadData(basePath, dataset, scenario, this);
+        dataInOut.loadData(basePath, dataset, scenario, this);
     }
 
     public void setTimeConfiguration(double[][] timeConfiguration) {
@@ -599,5 +602,49 @@ public class DataStorer {
 
     public void setPriceConfiguration(double[] priceConfiguration) {
         this.priceConfiguration = priceConfiguration;
+    }
+
+    public void loadTimeConfiguration() {
+        dataInOut.loadTimeConfiguration();
+    }
+
+    public void loadPriceConfiguration() {
+        dataInOut.loadPriceConfiguration();
+    }
+
+	public Solution loadGreedyHeuristicSolution(String solutionPath) {
+		return dataInOut.loadGreedyHeuristicSolution(solutionPath);
+	}
+
+	public void makeShapeFiles(String path, Solution soln) {
+        dataInOut.makeShapeFiles(path, soln);
+	}
+
+	public void makeCandidateShapeFiles(String path) {
+        dataInOut.makeCandidateShapeFiles(path);
+	}
+
+	public void makeSolutionFile(String path, Solution soln) {
+        dataInOut.makeSolutionFile(path, soln);
+	}
+
+	public void makePriceAggregationFile(String path, String content) {
+        dataInOut.makePriceAggregationFile(path, content);
+	}
+
+	public void downloadFile(String urlPath) {
+        dataInOut.downloadFile(urlPath);
+	}
+
+	public Solution loadSolution(String solutionPath, int timeslot) {
+        return dataInOut.loadSolution(solutionPath, timeslot);
+	}
+
+	public int determineNumTimeslots(String mpsFilePath) {
+        return dataInOut.determineNumTimeslots(mpsFilePath);
+    }
+    
+    public void saveHeuristicSolution(File solutionDirectory, GreedyHeuristic heuristic) {
+        dataInOut.saveHeuristicSolution(solutionDirectory, heuristic);
     }
 }

--- a/src/gui/ControlActions.java
+++ b/src/gui/ControlActions.java
@@ -5,7 +5,6 @@ import com.bbn.openmap.dataAccess.shape.EsriPolyline;
 import com.bbn.openmap.dataAccess.shape.EsriPolylineList;
 import com.bbn.openmap.dataAccess.shape.EsriShapeExport;
 import com.bbn.openmap.omGraphics.OMGraphic;
-import dataStore.DataInOut;
 import dataStore.DataStorer;
 import dataStore.Edge;
 import dataStore.Sink;
@@ -265,7 +264,7 @@ public class ControlActions {
                 } else if (modelVersion == 2) {
                     MPSWriter.writeCapPriceMPS("price.mps", data, Double.parseDouble(crf), Double.parseDouble(numYears), Double.parseDouble(capacityTarget), basePath, dataset, scenario, modelVersion);
                 } else if (modelVersion == 3) {
-                    DataInOut.loadTimeConfiguration();
+                    data.loadTimeConfiguration();
                     MPSWriter.writeSimpleTimeMPS("time.mps", data, Double.parseDouble(crf), basePath, dataset, scenario);
                 }
             }
@@ -275,7 +274,7 @@ public class ControlActions {
     // Price simulation
     public void runPriceSimulation(String crf, String numYears, String inputPrice, String numPairs, int modelVersion) {
         // Load simulation parmeters.
-        DataInOut.loadPriceConfiguration();
+        data.loadPriceConfiguration();
         double prices[] = data.getPriceConfiguration();
         if (prices == null) {
             prices = new double[]{Double.parseDouble(inputPrice)};
@@ -306,10 +305,10 @@ public class ControlActions {
             runGreedyHeuristic(crf, numYears, inputPrice, numPairs, modelVersion, solutionPriceDirectory);
 
             // Create shapefiles.
-            Solution soln = DataInOut.loadGreedyHeuristicSolution(basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/" + "price-" + price + "h");
-            DataInOut.makeShapeFiles(basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/" + "price-" + price + "h", soln);
-            DataInOut.makeCandidateShapeFiles(basePath + "/" + dataset + "/Scenarios/" + scenario);
-            DataInOut.makeSolutionFile(basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/" + "price-" + price + "h", soln);
+            Solution soln = data.loadGreedyHeuristicSolution(basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/" + "price-" + price + "h");
+            data.makeShapeFiles(basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/" + "price-" + price + "h", soln);
+            data.makeCandidateShapeFiles(basePath + "/" + dataset + "/Scenarios/" + scenario);
+            data.makeSolutionFile(basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/" + "price-" + price + "h", soln);
 
             // Update aggregation file.
             aggregateResults.append(price + "," + soln.getAnnualCaptureAmount() + "," + soln.getNumOpenedSources() + "," + soln.getNumOpenedSinks() + ",TBD,");
@@ -318,7 +317,7 @@ public class ControlActions {
         }
 
         // Write aggregation file.
-        DataInOut.makePriceAggregationFile(basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/aggregateResults.csv", aggregateResults.toString());
+        data.makePriceAggregationFile(basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/aggregateResults.csv", aggregateResults.toString());
     }
 
     // Heuristic
@@ -347,7 +346,7 @@ public class ControlActions {
         heuristic.solve(Integer.parseInt(numPairs), modelVersion);
 
         // Save solution
-        DataInOut.saveHeuristicSolution(directory, heuristic);
+        data.saveHeuristicSolution(directory, heuristic);
     }
 
     private void runFlowHeuristic(String crf, String numYears, String capacityTarget, int modelVersion) {
@@ -451,7 +450,7 @@ public class ControlActions {
                 // Make solution sub directories.
                 if (modelVersion == 3) {
                     // Determine number of timeslots from MPS file.
-                    int numTimeslots = DataInOut.determineNumTimeslots(mipPath);
+                    int numTimeslots = data.determineNumTimeslots(mipPath);
 
                     for (int timeslot = 1; timeslot <= numTimeslots; timeslot++) {
                         File solutionSubDirectory = new File(basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/" + run + "/timeslot-" + timeslot);
@@ -492,7 +491,7 @@ public class ControlActions {
                 @Override
                 public void changed(ObservableValue<? extends String> observableValue, String oldLoc, String newLoc) {
                     if (newLoc.contains("download")) {
-                        DataInOut.downloadFile(newLoc);
+                        data.downloadFile(newLoc);
                     }
                 }
             });
@@ -599,29 +598,29 @@ public class ControlActions {
             String solutionPath = basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/" + file;
 
             if (file.contains("greedy")) {
-                Solution soln = DataInOut.loadGreedyHeuristicSolution(solutionPath);
+                Solution soln = data.loadGreedyHeuristicSolution(solutionPath);
                 displaySolution(file, soln, solutionValues);
             } else if (file.contains("flow")) {
-                Solution soln = DataInOut.loadSolution(solutionPath, -1);
+                Solution soln = data.loadSolution(solutionPath, -1);
                 displaySolution(file, soln, solutionValues);
             } else if (file.contains("cap")) {
-                Solution soln = DataInOut.loadSolution(solutionPath, -1);
+                Solution soln = data.loadSolution(solutionPath, -1);
                 displaySolution(file, soln, solutionValues);
             } else if (file.contains("price")) {
-                Solution soln = DataInOut.loadSolution(solutionPath, -1);
+                Solution soln = data.loadSolution(solutionPath, -1);
                 displaySolution(file, soln, solutionValues);
             } else if (file.contains("time")) {
                 gui.showSubSolutionMenu();
 
                 // Populate sub directory
-                int numTimeslots = DataInOut.determineNumTimeslots(solutionPath + "/time.mps");
+                int numTimeslots = data.determineNumTimeslots(solutionPath + "/time.mps");
                 ArrayList<String> solns = new ArrayList<>();
                 for (int timeslot = 1; timeslot <= numTimeslots; timeslot++) {
                     solns.add("timeslot-" + timeslot);
                 }
                 gui.getSolutionChoice().setItems(FXCollections.observableArrayList(solns));
             } else {
-                Solution soln = DataInOut.loadSolution(solutionPath, -1);
+                Solution soln = data.loadSolution(solutionPath, -1);
                 displaySolution(file, soln, solutionValues);
             }
         }
@@ -631,7 +630,7 @@ public class ControlActions {
         if (solutionName != null && solutionName.contains("timeslot-")) {
             int timeslot = Integer.parseInt(solutionName.substring(9)) - 1;
             String solutionPath = basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/" + parent;
-            Solution soln = DataInOut.loadSolution(solutionPath, timeslot);
+            Solution soln = data.loadSolution(solutionPath, timeslot);
             displaySolution(parent + "/" + solutionName, soln, solutionValues);
         }
     }
@@ -720,9 +719,9 @@ public class ControlActions {
         solutionValues[12].setText(Double.toString(round(soln.getUnitTotalCost(), 2)));
 
         // Write to shapefiles.
-        DataInOut.makeShapeFiles(basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/" + file, soln);
-        DataInOut.makeCandidateShapeFiles(basePath + "/" + dataset + "/Scenarios/" + scenario);
-        DataInOut.makeSolutionFile(basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/" + file, soln);
+        data.makeShapeFiles(basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/" + file, soln);
+        data.makeCandidateShapeFiles(basePath + "/" + dataset + "/Scenarios/" + scenario);
+        data.makeSolutionFile(basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/" + file, soln);
 
         //determineROW(soln, basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/" + file);
     }
@@ -867,7 +866,7 @@ public class ControlActions {
         HashMap<Sink, Integer> sinkPopularity = new HashMap<>();
         HashMap<Edge, Integer> edgePopularity = new HashMap<>();
         for (int i = 0; i < 100; i++) {
-            Solution soln = DataInOut.loadSolution(basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/" + file + "/run" + i, -1);
+            Solution soln = data.loadSolution(basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/" + file + "/run" + i, -1);
 
             HashMap<Edge, Double> edgeTransportAmounts = soln.getEdgeTransportAmounts();
             HashMap<Source, Double> sourceCaptureAmounts = soln.getSourceCaptureAmounts();
@@ -940,7 +939,7 @@ public class ControlActions {
         }
 
         // Write to shapefiles.
-        DataInOut.makeShapeFiles(basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/" + file, aggSoln);
+        data.makeShapeFiles(basePath + "/" + dataset + "/Scenarios/" + scenario + "/Results/" + file, aggSoln);
     }
 
     public double rawXtoDisplayX(double rawX) {


### PR DESCRIPTION
Removes static references on DataInOut. Each instance of DataStorer gets its own instance of DataInOut. This works better in a multi-user web context -- each request creates its own DataStorer instance and loads that request's data separately from other concurrent requests.