### PR TITLE
Defensively parse numWells as Double since it may be a floating point number

### DIFF
--- a/src/dataStore/DataInOut.java
+++ b/src/dataStore/DataInOut.java
@@ -809,7 +809,7 @@ public class DataInOut {
                                 soln.setEdgeTrend(new Edge(unidirEdge.v1, unidirEdge.v2), Integer.parseInt(components[2]));
                             }
                         } else if (components[0].equals("w")) {
-                            soln.addSinkNumWells(sinks[Integer.parseInt(components[1])], Double.valueOf(variable[2]).intValue());
+                            soln.addSinkNumWells(sinks[Integer.parseInt(components[1])], (int) Math.round(Double.parseDouble(variable[2])));
                         }
                     } else {
                         if (components[0].equals("a") && (Integer.parseInt(components[2]) == timeslot)) {

--- a/src/dataStore/DataInOut.java
+++ b/src/dataStore/DataInOut.java
@@ -809,7 +809,7 @@ public class DataInOut {
                                 soln.setEdgeTrend(new Edge(unidirEdge.v1, unidirEdge.v2), Integer.parseInt(components[2]));
                             }
                         } else if (components[0].equals("w")) {
-                            soln.addSinkNumWells(sinks[Integer.parseInt(components[1])], Integer.parseInt(variable[2]));
+                            soln.addSinkNumWells(sinks[Integer.parseInt(components[1])], Double.valueOf(variable[2]).intValue());
                         }
                     } else {
                         if (components[0].equals("a") && (Integer.parseInt(components[2]) == timeslot)) {


### PR DESCRIPTION
Although the variable value should be an integer, CPLEX sometimes returns a floating point number.