### PR TITLE
Add getters for extracting cost network data

### DIFF
--- a/src/dataStore/DataStorer.java
+++ b/src/dataStore/DataStorer.java
@@ -493,6 +493,14 @@ public class DataStorer {
         return priceConfiguration;
     }
 
+    public double[][] getConstructionCosts() {
+        return constructionCosts;
+    }
+
+    public double[][] getRoutingCosts() {
+        return routingCosts;
+    }
+
     // Data element set methods
     // Heuristic
     public void setProjectLength(int projectLength) {


### PR DESCRIPTION
This PR adds a couple of getters that are used to extract the network cost data from DataStorer so that this data can be cached and reused in subsequent instances of DataStorer.

This is needed by https://github.com/SciGaP/simccs-maptool/issues/69 for caching the national cost surface data.